### PR TITLE
adding support for RestrictedPicklist

### DIFF
--- a/apex-mdapi/src/classes/MetadataService.cls
+++ b/apex-mdapi/src/classes/MetadataService.cls
@@ -9410,12 +9410,14 @@ public class MetadataService {
     public class Picklist {
         public String controllingField;
         public MetadataService.PicklistValue[] picklistValues;
+        public Boolean restrictedPicklist;
         public Boolean sorted;
         private String[] controllingField_type_info = new String[]{'controllingField','http://soap.sforce.com/2006/04/metadata',null,'0','1','false'};
+        private String[] restrictedPicklist_type_info = new String[]{'restrictedPicklist','http://soap.sforce.com/2006/04/metadata',null,'0','1','false'};
         private String[] picklistValues_type_info = new String[]{'picklistValues','http://soap.sforce.com/2006/04/metadata',null,'0','-1','false'};
         private String[] sorted_type_info = new String[]{'sorted','http://soap.sforce.com/2006/04/metadata',null,'1','1','false'};
         private String[] apex_schema_type_info = new String[]{'http://soap.sforce.com/2006/04/metadata','true','false'};
-        private String[] field_order_type_info = new String[]{'controllingField','picklistValues','sorted'};
+        private String[] field_order_type_info = new String[]{'controllingField','picklistValues','restrictedPicklist','sorted'};
     }
     public class deploy_element {
         public String ZipFile;


### PR DESCRIPTION
I added the metadata properties for RestrictedPicklist metadata to fix the apex type not found exception. 

> Web service callout failed: Unable to parse callout response. Apex type not found for element restrictedPicklist

Closes #106