### PR TITLE
Fix for issue where sandbox name contains capital letters: salesforce…

### DIFF
--- a/apex-mdapi/src/classes/MetadataService.cls
+++ b/apex-mdapi/src/classes/MetadataService.cls
@@ -10750,7 +10750,7 @@ public class MetadataService {
         private String[] field_order_type_info = new String[]{'active','adjustmentsSettings','displayedCategoryApiNames','forecastRangeSettings','forecastedCategoryApiNames','isAmount','isAvailable','isQuantity','managerAdjustableCategoryApiNames','masterLabel','name','opportunityListFieldsLabelMappings','opportunityListFieldsSelectedSettings','opportunityListFieldsUnselectedSettings','ownerAdjustableCategoryApiNames','quotasSettings'};
     }
     public class MetadataPort {
-        public String endpoint_x = URL.getSalesforceBaseUrl().toExternalForm() + '/services/Soap/m/37.0';
+        public String endpoint_x = URL.getSalesforceBaseUrl().toExternalForm().toLowerCase() + '/services/Soap/m/37.0';
         public Map<String,String> inputHttpHeaders_x;
         public Map<String,String> outputHttpHeaders_x;
         public String clientCertName_x;


### PR DESCRIPTION
… will callout for token to all-lowercase hostname in URL, but MetadataService will callout to the actual sandbox name as capitalized - hence requiring an additional Remote Site Setting to be configured, since the matching there is case-sensitive.

Thus, adding a lowercasing of the generated org url will not disturb the MetadataService callout, but allow us to get by with just a single Remote Site Setting (the all-lowercase one). 