### PR TITLE
Remote sites became redundant with Winter'19

### DIFF
--- a/apex-mdapi/src/classes/MetadataService.cls
+++ b/apex-mdapi/src/classes/MetadataService.cls
@@ -13190,7 +13190,7 @@ public class MetadataService {
         private String[] field_order_type_info = new String[]{'active','adjustmentsSettings','displayedCategoryApiNames','forecastRangeSettings','forecastedCategoryApiNames','forecastingDateType','hasProductFamily','isAmount','isAvailable','isQuantity','managerAdjustableCategoryApiNames','masterLabel','name','opportunityListFieldsLabelMappings','opportunityListFieldsSelectedSettings','opportunityListFieldsUnselectedSettings','opportunitySplitName','ownerAdjustableCategoryApiNames','quotasSettings','territory2ModelName'};
     }
     public class MetadataPort {
-        public String endpoint_x = URL.getSalesforceBaseUrl().toExternalForm() + '/services/Soap/m/42.0';
+        public String endpoint_x = Url.getOrgDomainUrl().toExternalForm() + '/services/Soap/m/44.0';
         public Map<String,String> inputHttpHeaders_x;
         public Map<String,String> outputHttpHeaders_x;
         public String clientCertName_x;


### PR DESCRIPTION
With Winter'19 remote site setting for Metadata API calls from Apex are not needed anymore https://releasenotes.docs.salesforce.com/en-us/winter19/release-notes/rn_apex_streamline_api_calls.htm

I just replace the URL creation code. Someone also might want to remove the Remote site helper files.